### PR TITLE
User registration and flatpages added

### DIFF
--- a/HandprintGenerator/urls.py
+++ b/HandprintGenerator/urls.py
@@ -9,5 +9,9 @@ urlpatterns = [
   #  url(r'^create-user$', views.create_user),
 
 	url(r'^new', views.new_action_item, name='new_action_item'),
+	url(r'^register', views.new_user, name='register'),
+	url(r'^about-us/$', views.flatpage, {'url': '/about-us/'}, name='about'),
+    url(r'^privacy-policy/$', views.flatpage, {'url': '/privacy-policy/'}, name='privacy')
+    url(r'^contact-us/$', views.flatpage, {'url': '/contact-us/'}, name='contact'),
 
 ]

--- a/HandprintGenerator/views.py
+++ b/HandprintGenerator/views.py
@@ -51,6 +51,19 @@ def new_action_item(request):
 
     return render(request, 'HandprintGenerator/new_action_idea.html', context)
 
+@transaction.atomic
+def new_user(request):
+	context = {}
+	form = RegistrationForm(request.POST)
+	conext['register_form'] = form
+	if form.is_valid():
+		new_user = form.save(commit=False)
+		new_user.date_created = datetime.datetime
+		new_user.save()
+		return HttpResponseRedirect('.')
+		#new users get sent to action idea index? 
+	return render(request, 'HandprintGenerator/index.html', context)
+
 #@transaction.atomic
 #def create_user(request):
 #    context = {

--- a/Handprinter/settings.py
+++ b/Handprinter/settings.py
@@ -22,7 +22,7 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 SECRET_KEY = 'admin'
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = False
+DEBUG = True
 
 ALLOWED_HOSTS = []
 
@@ -37,6 +37,8 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'django.contrib.sites'
+    'django.contrib.flatpages'
 ]
 
 MIDDLEWARE_CLASSES = [
@@ -48,6 +50,7 @@ MIDDLEWARE_CLASSES = [
     'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    'django.contrib.flatpages.middleware.FlatpageFallbackMiddleware',
 ]
 
 ROOT_URLCONF = 'Handprinter.urls'

--- a/Handprinter/urls.py
+++ b/Handprinter/urls.py
@@ -19,4 +19,5 @@ from django.contrib import admin
 urlpatterns = [
     url(r'^handprintgenerator/', include('HandprintGenerator.urls')),
     url(r'^admin/', admin.site.urls),
+  
 ]


### PR DESCRIPTION
Django has this feature called flatpages (https://docs.djangoproject.com/en/1.9/ref/contrib/flatpages/). All the sources I went to suggested using this to make the static pages. I seem to get it installed on my end, but when I go to create the actual static pages they won't render or load. 

I've added the flatpages package and the use registration form. See if flatpages installs properly on your end (I think it's manage.py migrate). If it works on your end, then that's a good step forward, but I'll need to figure out how to get the actual static pages to work.... 

If none of this works, don't accept the pull request. I'll see if I can fix it later. 